### PR TITLE
🦟: document appeared twice at a term. ex. term['the'] = ['doc1', 'doc1']

### DIFF
--- a/resources/term_frequency.py
+++ b/resources/term_frequency.py
@@ -30,13 +30,14 @@ class TermFrequency:
         """
         Process text, given a document title
         """
-        for term in sentence.split(' '):
+        for word in sentence.split(' '):
             self[doc_title].length += 1
-            self[doc_title][term] += 1
+            self[doc_title][word] += 1
 
-            if term not in self.terms.keys():
-                self.terms[term] = []
-            self.terms[term].append(doc_title)
+            if word not in self.terms.keys():
+                self.terms[word] = []
+            if doc_title not in self.terms[word]:
+                self.terms[word].append(doc_title)
 
 
 class DocCounter(Counter):  # pylint: disable=W0223

--- a/tests/test_term_frequency.py
+++ b/tests/test_term_frequency.py
@@ -78,3 +78,13 @@ class TestTermFrequency:
         word_document = self.term_index.terms["D42"]
 
         assert doc in word_document
+
+    def test_doc_do_not_appear_twice_lookup_word(self):
+        corpus = "the the"
+        doc = "D42"
+        self.term_index.process(doc, corpus)
+
+        word_documents = self.term_index.terms["the"]
+
+        assert len(word_documents) == 1
+


### PR DESCRIPTION
fixed a bug, where a document would be added twice to the word counter